### PR TITLE
Support for Initialization Vectors in AES symmetric Encryption/Decryption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.FXP
+*.BAK
 /Tests/FXUPERSIST*.XML
 /Tests/FXUResults.*
 /Tools/FxuClassFactory.dbf


### PR DESCRIPTION
Christof,

I intend to use foxCryptoNG as the base for a support Security Library to XMLSecurity, an XML Encryption/Signing set of VFP classes.

Other support Security Libraries already developed use Chilkat and OpenSSL.

Adding foxCryptoNG to this group would be really important because it would reduce the dependency of external tools that may not be readily available.

I'm starting with symmetric Encryption and Decryption, but since the XML Encryption specs require the use of an Initialization Vector with the AES based algorithms, I included the support for it in the Encrypt_AES and Decrypt_AES methods of a forked foxCryptoNG, while trying to respect your coding style.

I'm pulling the request for your consideration.